### PR TITLE
Updated setup.cfg to NOT use newest dash / pypandoc / waitress versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,14 +18,14 @@ package_dir =
 packages = find:
 python_requires = >=3.10
 install_requires =
-    dash >= 2.11.1
-    dash-bootstrap-components >= 1.4.1
-    dash-cytoscape >= 0.3.0
-    dash-extensions >= 1.0.3
-    dash-iconify >= 0.1.2
-    dash-mantine-components >= 0.12.1
-    pypandoc-binary >= 1.11
-    waitress >= 2.0.0
+    dash == 2.11.1
+    dash-bootstrap-components == 1.4.1
+    dash-cytoscape == 0.3.0
+    dash-extensions == 1.0.3
+    dash-iconify == 0.1.2
+    dash-mantine-components == 0.12.1
+    pypandoc-binary == 1.11
+    waitress == 2.0.0
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
At least dash doesn't seem to be backwards compatible, so the program won't run with the newest versions.

In general nice project idea and implementation, Seth!